### PR TITLE
Fixes PHP Notice when "body" property is not defined

### DIFF
--- a/include/S3.php
+++ b/include/S3.php
@@ -1966,6 +1966,8 @@ final class S3Request
 	*/
 	private function __responseWriteCallback(&$curl, &$data)
 	{
+		if ( ! isset($this->response->body)) $this->response->body = '';
+		
 		if (in_array($this->response->code, array(200, 206)) && $this->fp !== false)
 			return fwrite($this->fp, $data);
 		else


### PR DESCRIPTION
A PHP notice is thrown when $this->response->body is not set. This is because the code attempts to append to the $this->response->body property when it does not exist.

This PR fixes that error.
